### PR TITLE
Add useTitleTemplate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@ library will always make a queue of how we should fallback, ... This way we'll a
 visiting crawler.
 
 ```jsx
-import { useMeta, useLink, useLang, useTitle } from 'hooked-head';
+import {
+  useMeta,
+  useLink,
+  useLang,
+  useTitle,
+  useTitleTemplate,
+} from 'hooked-head';
 
 const App = () => {
   useLang('en');
+  useTitleTemplate('%s | 💭');
   useTitle('welcome to hooked-head');
   useMeta({ name: 'author', content: 'Jovi De Croock' });
   useLink({ rel: 'me', href: 'https://jovidecroock.com' });
@@ -27,13 +34,18 @@ If you need support for [Preact](https://preactjs.com/) you can import from `hoo
 
 ## Hooks
 
-This package exports `useTitle`, `useMeta`, `useLink` and `useLang`. These hooks
+This package exports `useTitle`, `useTitleTemplate`, `useMeta`, `useLink` and `useLang`. These hooks
 are used to control information conveyed by the `<head>` in an html document.
 
 ### useTitle
 
 This hook accepts a string that will be used to set the `document.title`, every time the
 given string changes it will update the property.
+
+### useTitleTemplate
+
+This hook accepts a string, which will be used to format the result of `useTitle` whenever
+it updates. Similar to react-helmet, the placeholder `%s` will be replaced with the `title`.
 
 ### useMeta
 

--- a/__tests__/ssr.useTitleTemplate.test.tsx
+++ b/__tests__/ssr.useTitleTemplate.test.tsx
@@ -1,0 +1,107 @@
+jest.mock('../src/utils', () => {
+  return {
+    isServerSide: true,
+  };
+});
+
+import * as React from 'react';
+import { useTitle, useTitleTemplate, toString } from '../src';
+import { render } from '@testing-library/react';
+
+describe('ssr with a template', () => {
+  it('should render to string (basic)', () => {
+    jest.useFakeTimers();
+    const MyComponent = () => {
+      useTitleTemplate('%s | you');
+      useTitle('hi');
+      return <p>hi</p>;
+    };
+
+    render(<MyComponent />);
+    jest.runAllTimers();
+    const { head, lang } = toString();
+    expect(head).toContain('<title>hi | you</title>');
+  });
+
+  it('should render to string (nested)', () => {
+    jest.useFakeTimers();
+    const MyComponent = (props: any) => {
+      useTitleTemplate('%s | you');
+      useTitle('hi');
+      return props.children;
+    };
+
+    const MyNestedComponent = () => {
+      useTitleTemplate('%s | you');
+      useTitle('bye');
+      return <p>hi</p>;
+    };
+
+    render(
+      <MyComponent>
+        <MyNestedComponent />
+      </MyComponent>
+    );
+    jest.runAllTimers();
+    const { head } = toString();
+    expect(head).toContain('<title>bye | you</title>');
+  });
+
+  it('should render to string (updates)', () => {
+    jest.useFakeTimers();
+    const MyComponent = (props: any) => {
+      useTitleTemplate('%s | you');
+      useTitle('hi');
+      return props.children;
+    };
+
+    const MyNestedComponent = ({ content, template }: any) => {
+      useTitle(content);
+      useTitleTemplate(template);
+      return <p>hi</p>;
+    };
+
+    const { rerender } = render(
+      <MyComponent>
+        <MyNestedComponent content="bye" template="%s | you" />
+      </MyComponent>
+    );
+    jest.runAllTimers();
+
+    rerender(
+      <MyComponent>
+        <MyNestedComponent content="foo" template="%s | you" />
+      </MyComponent>
+    );
+    jest.runAllTimers();
+    const { head } = toString();
+    expect(head).toContain('<title>foo | you</title>');
+  });
+
+  it('should render to string (removal)', () => {
+    jest.useFakeTimers();
+    const MyComponent = (props: any) => {
+      useTitleTemplate('%s | you');
+      useTitle('hi');
+      return props.children || <p>hi</p>;
+    };
+
+    const MyNestedComponent = ({ content }: any) => {
+      useTitleTemplate('%s | you');
+      useTitle(content);
+      return <p>hi</p>;
+    };
+
+    const { rerender } = render(
+      <MyComponent>
+        <MyNestedComponent content="bye" template="%s | you" />
+      </MyComponent>
+    );
+    jest.runAllTimers();
+
+    rerender(<MyComponent />);
+    jest.runAllTimers();
+    const { head } = toString();
+    expect(head).toContain('<title>hi | you</title>');
+  });
+});

--- a/__tests__/useTitleTemplate.test.tsx
+++ b/__tests__/useTitleTemplate.test.tsx
@@ -1,0 +1,235 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { act, render, cleanup } from '@testing-library/react';
+import { useTitle, useTitleTemplate } from '../src';
+import dispatcher from '../src/dispatcher';
+
+describe('useTitle', () => {
+  afterEach(() => {
+    cleanup();
+    dispatcher.reset!();
+  });
+
+  it('should fill in the title based on the template', async () => {
+    jest.useFakeTimers();
+    const MyComponent = ({
+      template,
+      title,
+    }: {
+      template: string;
+      title: string;
+    }) => {
+      useTitleTemplate(template);
+      useTitle(title);
+
+      return <p>hi</p>;
+    };
+
+    let rerender: any;
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent template="%s | Site" title="Super" />
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('Super | Site');
+
+    await act(async () => {
+      await rerender!(
+        <MyComponent title="itWorks" template="| ignoring the template" />
+      );
+    });
+    jest.runAllTimers();
+    expect(document.title).toEqual('itWorks');
+  });
+
+  it('should fill in the title based on the template even in reverse order', async () => {
+    jest.useFakeTimers();
+    const MyComponent = ({
+      template,
+      title,
+    }: {
+      template: string;
+      title: string;
+    }) => {
+      useTitle(title);
+      useTitleTemplate(template);
+
+      return <p>hi</p>;
+    };
+
+    let rerender: any;
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent template="%s | Site" title="Super" />
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('Super | Site');
+
+    await act(async () => {
+      await rerender!(
+        <MyComponent title="itWorks" template="| ignoring the template" />
+      );
+    });
+    jest.runAllTimers();
+    expect(document.title).toEqual('itWorks');
+  });
+
+  it('should restore the title', async () => {
+    jest.useFakeTimers();
+    const MyComponent = ({
+      title,
+      template,
+    }: {
+      title: string;
+      template: string;
+    }) => {
+      useTitleTemplate(template);
+      useTitle(title);
+      return <p>hi</p>;
+    };
+
+    let rerender: any;
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent title="coolStory" template="%s | Bruh" />
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('coolStory | Bruh');
+
+    await act(async () => {
+      await rerender!(<p>hi</p>);
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('');
+  });
+
+  it('should deeply fill in the title', async () => {
+    jest.useFakeTimers();
+    const MyComponent = ({
+      children,
+      title,
+      template,
+    }: {
+      children: any;
+      title: string;
+      template: string;
+    }) => {
+      useTitleTemplate(template);
+      useTitle(title);
+      return children;
+    };
+
+    const MyDeepComponent = ({ title }: { title: string }) => {
+      useTitle(title);
+      return <p>hi</p>;
+    };
+
+    let rerender: any;
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent title="coolStory" template="%s | Bruh">
+          <MyDeepComponent title="resetted" />
+        </MyComponent>
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('resetted | Bruh');
+
+    await act(async () => {
+      await rerender!(
+        <MyComponent title="coolStory" template="%s | Bruh">
+          <p>hi</p>
+        </MyComponent>
+      );
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('coolStory | Bruh');
+  });
+
+  it('should keep the templates deeply in order', async () => {
+    jest.useFakeTimers();
+    const MyComponent = ({
+      children,
+      title,
+      template,
+    }: {
+      children: any;
+      title: string;
+      template: string;
+    }) => {
+      useTitleTemplate(template);
+      useTitle(title);
+      return children;
+    };
+
+    const MyDeepComponent = ({
+      children,
+      title,
+      template,
+    }: {
+      children: any;
+      title: string;
+      template: string;
+    }) => {
+      useTitleTemplate(template);
+      useTitle(title);
+      return children;
+    };
+
+    const MyDeepestComponent = ({
+      title,
+      template,
+    }: {
+      title: string;
+      template?: string;
+    }) => {
+      if (template) {
+        useTitleTemplate(template);
+      }
+
+      useTitle(title);
+      return <p>hi</p>;
+    };
+
+    let rerender: any;
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent title="coolStory" template="%s | Bruh">
+          <MyDeepComponent title="resetted" template="%s | Bro">
+            <MyDeepestComponent title="innerStory" template="%s | Sis" />
+          </MyDeepComponent>
+        </MyComponent>
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('innerStory | Sis');
+
+    await act(async () => {
+      ({ rerender } = await render(
+        <MyComponent title="coolStory" template="%s | Bruh">
+          <MyDeepComponent title="resetted" template="%s | Bro">
+            <MyDeepestComponent title="innerStory" />
+          </MyDeepComponent>
+        </MyComponent>
+      ));
+    });
+
+    jest.runAllTimers();
+    expect(document.title).toEqual('innerStory | Bro');
+  });
+});

--- a/__tests__/useTitleTemplate.test.tsx
+++ b/__tests__/useTitleTemplate.test.tsx
@@ -38,46 +38,11 @@ describe('useTitle', () => {
 
     await act(async () => {
       await rerender!(
-        <MyComponent title="itWorks" template="| ignoring the template" />
+        <MyComponent title="itWorks" template="| without replacement" />
       );
     });
     jest.runAllTimers();
-    expect(document.title).toEqual('itWorks');
-  });
-
-  it('should fill in the title based on the template even in reverse order', async () => {
-    jest.useFakeTimers();
-    const MyComponent = ({
-      template,
-      title,
-    }: {
-      template: string;
-      title: string;
-    }) => {
-      useTitle(title);
-      useTitleTemplate(template);
-
-      return <p>hi</p>;
-    };
-
-    let rerender: any;
-
-    await act(async () => {
-      ({ rerender } = await render(
-        <MyComponent template="%s | Site" title="Super" />
-      ));
-    });
-
-    jest.runAllTimers();
-    expect(document.title).toEqual('Super | Site');
-
-    await act(async () => {
-      await rerender!(
-        <MyComponent title="itWorks" template="| ignoring the template" />
-      );
-    });
-    jest.runAllTimers();
-    expect(document.title).toEqual('itWorks');
+    expect(document.title).toEqual('| without replacement');
   });
 
   it('should restore the title', async () => {

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -165,7 +165,8 @@ const createDispatcher = () => {
     ) => {
       if (type === 'title') {
         titleQueue[titleQueue.indexOf(prevPayload as string)] = payload;
-        if (!isServerSide) document.title = payload;
+        if (!isServerSide)
+          document.title = applyTitleTemplate(payload, titleTemplateQueue[0]);
       } else if (type === 'titleTemplate') {
         titleTemplateQueue[
           titleTemplateQueue.indexOf(prevPayload as string)

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -104,18 +104,25 @@ const createDispatcher = () => {
     _addToQueue: (type: HeadType, payload: MetaPayload | string): void => {
       processQueue();
 
-      if (type === 'title') {
-        titleQueue.splice(currentTitleIndex++, 0, payload as string);
-      } else if (type === 'meta') {
-        metaQueue.splice(currentMetaIndex++, 0, payload as MetaPayload);
-      } else if (type === 'titleTemplate') {
-        titleTemplateQueue.splice(
-          currentTitleTemplateIndex++,
-          0,
-          payload as string
-        );
-      } else {
-        linkQueue.push(payload);
+      switch (type) {
+        case 'title':
+          titleQueue.splice(currentTitleIndex++, 0, payload as string);
+          break;
+
+        case 'titleTemplate':
+          titleTemplateQueue.splice(
+            currentTitleTemplateIndex++,
+            0,
+            payload as string
+          );
+          break;
+
+        case 'meta':
+          metaQueue.splice(currentMetaIndex++, 0, payload as MetaPayload);
+          break;
+
+        default:
+          linkQueue.push(payload);
       }
     },
     _removeFromQueue: (type: HeadType, payload: MetaPayload | string) => {

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -12,13 +12,8 @@ export interface MetaPayload {
   content: string;
 }
 
-const applyTitleTemplate = (title: string, template?: string) => {
-  if (title && template) {
-    return template.replace(/%s/g, title);
-  }
-
-  return title;
-};
+const applyTitleTemplate = (title: string, template?: string) =>
+  title && template ? template.replace(/%s/g, title) : title;
 
 const changeOrCreateMetaTag = (meta: MetaPayload) => {
   if (!isServerSide) {
@@ -129,7 +124,7 @@ const createDispatcher = () => {
         if (!isServerSide)
           document.title = applyTitleTemplate(
             titleQueue[0] || '',
-            titleTemplateQueue[0] || undefined
+            titleTemplateQueue[0]
           );
       } else {
         const oldMeta = metaQueue[metaQueue.indexOf(payload as MetaPayload)];

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -12,7 +12,7 @@ export interface MetaPayload {
   content: string;
 }
 
-const applyTemplate = (title: string, template?: string) => {
+const applyTitleTemplate = (title: string, template?: string) => {
   if (title && template) {
     return template.replace(/%s/g, title);
   }
@@ -87,7 +87,10 @@ const createDispatcher = () => {
         timeout = null;
         const visited = new Set();
         if (!isServerSide)
-          document.title = applyTemplate(titleQueue[0], titleTemplateQueue[0]);
+          document.title = applyTitleTemplate(
+            titleQueue[0],
+            titleTemplateQueue[0]
+          );
 
         metaQueue.forEach((meta) => {
           if (!visited.has(meta.charset ? meta.keyword : meta[meta.keyword])) {
@@ -124,7 +127,7 @@ const createDispatcher = () => {
       if (type === 'title') {
         titleQueue.splice(titleQueue.indexOf(payload as string), 1);
         if (!isServerSide)
-          document.title = applyTemplate(
+          document.title = applyTitleTemplate(
             titleQueue[0] || '',
             titleTemplateQueue[0] || undefined
           );
@@ -185,7 +188,7 @@ const createDispatcher = () => {
       //  Then do a similar for the meta's. (will also need to add links, and add a linkQueue). Note that both queues
       //  will need a reset to prevent memory leaks.
       const visited = new Set();
-      const title = applyTemplate(titleQueue[0], titleTemplateQueue[0]);
+      const title = applyTitleTemplate(titleQueue[0], titleTemplateQueue[0]);
       const stringified = `
         <title>${title}</title>
         ${metaQueue.reduce((acc, meta) => {

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -1,7 +1,7 @@
 import { Name, CharSet, HttpEquiv, Property } from '../types';
 import { isServerSide } from '../utils';
 
-type HeadType = 'title' | 'meta' | 'link';
+type HeadType = 'title' | 'titleTemplate' | 'meta' | 'link';
 type MetaKeyword = 'name' | 'charset' | 'http-equiv' | 'property';
 export interface MetaPayload {
   keyword: MetaKeyword;
@@ -11,6 +11,14 @@ export interface MetaPayload {
   property: Property;
   content: string;
 }
+
+const applyTemplate = (title: string, template?: string) => {
+  if (title && template) {
+    return template.replace(/%s/g, title);
+  }
+
+  return title;
+};
 
 const changeOrCreateMetaTag = (meta: MetaPayload) => {
   if (!isServerSide) {
@@ -61,8 +69,10 @@ const createDispatcher = () => {
   let lang: string;
   let linkQueue: any[] = [];
   let titleQueue: string[] = [];
+  let titleTemplateQueue: string[] = [];
   let metaQueue: MetaPayload[] = [];
   let currentTitleIndex = 0;
+  let currentTitleTemplateIndex = 0;
   let currentMetaIndex = 0;
 
   // A process can be debounced by one frame timing,
@@ -76,7 +86,8 @@ const createDispatcher = () => {
       timeout = setTimeout(() => {
         timeout = null;
         const visited = new Set();
-        if (!isServerSide) document.title = titleQueue[0];
+        if (!isServerSide)
+          document.title = applyTemplate(titleQueue[0], titleTemplateQueue[0]);
 
         metaQueue.forEach((meta) => {
           if (!visited.has(meta.charset ? meta.keyword : meta[meta.keyword])) {
@@ -85,7 +96,7 @@ const createDispatcher = () => {
           }
         });
 
-        currentTitleIndex = currentMetaIndex = 0;
+        currentTitleIndex = currentTitleTemplateIndex = currentMetaIndex = 0;
       }, 1000 / 60 /* One second divided by the max browser fps. */);
     };
   })();
@@ -99,6 +110,12 @@ const createDispatcher = () => {
         titleQueue.splice(currentTitleIndex++, 0, payload as string);
       } else if (type === 'meta') {
         metaQueue.splice(currentMetaIndex++, 0, payload as MetaPayload);
+      } else if (type === 'titleTemplate') {
+        titleTemplateQueue.splice(
+          currentTitleTemplateIndex++,
+          0,
+          payload as string
+        );
       } else {
         linkQueue.push(payload);
       }
@@ -106,7 +123,11 @@ const createDispatcher = () => {
     _removeFromQueue: (type: HeadType, payload: MetaPayload | string) => {
       if (type === 'title') {
         titleQueue.splice(titleQueue.indexOf(payload as string), 1);
-        if (!isServerSide) document.title = titleQueue[0] || '';
+        if (!isServerSide)
+          document.title = applyTemplate(
+            titleQueue[0] || '',
+            titleTemplateQueue[0] || undefined
+          );
       } else {
         const oldMeta = metaQueue[metaQueue.indexOf(payload as MetaPayload)];
 
@@ -140,6 +161,10 @@ const createDispatcher = () => {
       if (type === 'title') {
         titleQueue[titleQueue.indexOf(prevPayload as string)] = payload;
         if (!isServerSide) document.title = payload;
+      } else if (type === 'titleTemplate') {
+        titleTemplateQueue[
+          titleTemplateQueue.indexOf(prevPayload as string)
+        ] = payload;
       } else {
         changeOrCreateMetaTag(
           (metaQueue[metaQueue.indexOf(prevPayload as MetaPayload)] = payload)
@@ -160,8 +185,9 @@ const createDispatcher = () => {
       //  Then do a similar for the meta's. (will also need to add links, and add a linkQueue). Note that both queues
       //  will need a reset to prevent memory leaks.
       const visited = new Set();
+      const title = applyTemplate(titleQueue[0], titleTemplateQueue[0]);
       const stringified = `
-        <title>${titleQueue[0]}</title>
+        <title>${title}</title>
         ${metaQueue.reduce((acc, meta) => {
           if (!visited.has(meta.charset ? meta.keyword : meta[meta.keyword])) {
             visited.add(meta.charset ? meta.keyword : meta[meta.keyword]);
@@ -179,6 +205,7 @@ const createDispatcher = () => {
         }, '')}
       `;
       titleQueue = [];
+      titleTemplateQueue = [];
       metaQueue = [];
       linkQueue = [];
       return { head: stringified, lang };

--- a/src/hooks/useTitleTemplate.ts
+++ b/src/hooks/useTitleTemplate.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import dispatcher from '../dispatcher';
+
+export const useTitleTemplate = (template: string) => {
+  const hasMounted = useRef(false);
+  const prevTitleTemplate = useRef<string | undefined>();
+
+  useEffect(() => {
+    if (hasMounted.current) {
+      dispatcher._change(
+        'titleTemplate',
+        prevTitleTemplate.current as string,
+        (prevTitleTemplate.current = template)
+      );
+    }
+  }, [template]);
+
+  useEffect(() => {
+    hasMounted.current = true;
+    dispatcher._addToQueue(
+      'titleTemplate',
+      (prevTitleTemplate.current = template)
+    );
+    return () => {
+      hasMounted.current = false;
+      dispatcher._removeFromQueue(
+        'titleTemplate',
+        prevTitleTemplate.current as string
+      );
+    };
+  }, []);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './hooks/useLang';
 export * from './hooks/useLink';
 export * from './hooks/useMeta';
 export * from './hooks/useTitle';
+export * from './hooks/useTitleTemplate';
 export * from './types';
 export const toString = dispatcher._toString;


### PR DESCRIPTION
Implements a new hook: `useTitleTemplate` which can be used to format the output of `useTitle`. The `%s` part of the template will be replaced with `title`.

### Usage

```js
useTitleTemplate('%s | Site');
useTitle('hooked-head')

// title will be: "hooked-head | Site"
```
