### PR TITLE
Added `type` to LinkOptions

### DIFF
--- a/src/hooks/useLink.ts
+++ b/src/hooks/useLink.ts
@@ -10,6 +10,7 @@ interface LinkOptions {
   href?: string;
   sizes?: string;
   crossorigin?: 'anonymous' | 'use-credentials';
+  type?: string;
 }
 
 export const useLink = (options: LinkOptions) => {


### PR DESCRIPTION
`type` is neither experimental or deprecated, and is seen a lot in the wild.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type